### PR TITLE
Bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dickeyy/go-distances
 
-go 1.23.4
+go 1.24


### PR DESCRIPTION
closes #2 

bumped from 1.23.x to 1.24